### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,6 +2,9 @@ name: Django CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs: 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/1](https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not appear to require write access to the repository contents, we can set the `contents` permission to `read`. This will limit the `GITHUB_TOKEN` permissions to the minimum required for the workflow to execute safely.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, if specific jobs require different permissions, the `permissions` block can be added to individual jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
