### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,6 @@
 name: Security Scan
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 0 * * *'  # Diario a medianoche


### PR DESCRIPTION
Potential fix for [https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/9](https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's steps:
1. The `actions/checkout` action requires `contents: read` to fetch the repository's code.
2. The `ossf/scorecard-action` and `github/codeql-action/upload-sarif` actions do not require additional permissions beyond `contents: read`.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
