### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
     paths: [ 'src/**', 'deploy/**' ]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/2](https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with Docker and deploys code, so it likely only needs `contents: read` permissions. If additional permissions are required (e.g., for pull requests or issues), they can be added explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
