### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,10 +6,12 @@ on:
   pull_request:
     branches: ['*']
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.10'
   DJANGO_SETTINGS_MODULE: 'backend.settings'
-
 jobs:
   validate-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/3](https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Since the workflow primarily involves testing, validation, and deployment tasks, it does not require write access to the repository contents. We will set `contents: read` as the default permission for all jobs. If any job requires additional permissions, they can be specified individually within that job's `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
