### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-on-schedule.yml
+++ b/.github/workflows/generate-on-schedule.yml
@@ -1,4 +1,6 @@
 name: Generación Programada
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 9 * * 1-5' # Ejecutar días hábiles a las 9AM


### PR DESCRIPTION
Potential fix for [https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/6](https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, it does not appear to need write access to the repository contents. Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
