### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,6 @@
 name: CI Pipeline
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/18](https://github.com/MechBot-2x/mechbot-templates/security/code-scanning/18)

To fix the problem, we should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the top level of the workflow file (before `jobs:`), so it applies to all jobs unless overridden. Since the workflow only checks out code and runs tests, the minimal required permission is `contents: read`. This change should be made at the top of `.github/workflows/CI.yml`, after the `name:` and before `on:` or `jobs:`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
